### PR TITLE
Fixed asset urls naming a minified bundle older versions never published

### DIFF
--- a/lib/framework/version.rb
+++ b/lib/framework/version.rb
@@ -75,13 +75,13 @@ module Framework
     def css_url
       return self.class.development_asset_url("plugins.css") if self.class.development_mode?
 
-      "#{asset_host}/css/#{@number}/plugins.min.css"
+      "#{asset_host}/css/#{@number}/#{published_bundle('css')}"
     end
 
     def js_url
       return self.class.development_asset_url("plugins.js") if self.class.development_mode?
 
-      "#{asset_host}/js/#{@number}/plugins.min.js"
+      "#{asset_host}/js/#{@number}/#{published_bundle('js')}"
     end
 
     # Theme stylesheets this version publishes, keyed by theme id. Empty for versions
@@ -107,6 +107,14 @@ module Framework
     def major = Gem::Version.new(number).segments.first
 
     private
+
+    # Releases before 3.0 have no minified build and never will, so the name is checked
+    # rather than assumed.
+    def published_bundle(extension)
+      minified = "plugins.min.#{extension}"
+
+      Framework.public_root.join(extension, @number, minified).file? ? minified : "plugins.#{extension}"
+    end
 
     def asset_host
       host = Rails.application.config.asset_host

--- a/spec/lib/framework/version_spec.rb
+++ b/spec/lib/framework/version_spec.rb
@@ -71,16 +71,44 @@ RSpec.describe Framework::Version do
     end
   end
 
-  describe '#css_url' do
-    it 'points at the version-scoped plugins stylesheet' do
-      expect(version.css_url).to end_with("/css/#{number}/plugins.min.css")
+  shared_examples 'a bundle url' do |extension|
+    context 'with a version that published a minified build' do
+      let(:number) { '3.1.8' }
+
+      it 'links the minified bundle' do
+        expect(url).to end_with("/#{extension}/#{number}/plugins.min.#{extension}")
+      end
+    end
+
+    context 'with a version released before minification' do
+      let(:number) { '1.0.0' }
+
+      it 'links the plain bundle' do
+        expect(url).to end_with("/#{extension}/#{number}/plugins.#{extension}")
+      end
+    end
+
+    context 'when serving the live build' do
+      let(:number) { '3.1.8' }
+
+      before { allow(described_class).to receive(:development_mode?).and_return(true) }
+
+      it 'links the live build instead of a release' do
+        expect(url).to start_with("/framework-dev/plugins.#{extension}")
+      end
     end
   end
 
+  describe '#css_url' do
+    let(:url) { version.css_url }
+
+    it_behaves_like 'a bundle url', 'css'
+  end
+
   describe '#js_url' do
-    it 'points at the version-scoped plugins script' do
-      expect(version.js_url).to end_with("/js/#{number}/plugins.min.js")
-    end
+    let(:url) { version.js_url }
+
+    it_behaves_like 'a bundle url', 'js'
   end
 
   describe '#theme_css_urls' do


### PR DESCRIPTION
css_url and js_url always ask for plugins.min.css / plugins.min.js, but minification only arrived with the 3.0 build pipeline. 26 of the 43 published versions ship the plain bundle only, so any host pinned below 3.0 gets a 404. Served off a static root that returns an HTML error page, so the browser rejects the stylesheet or refuses the script for a disallowed MIME type.

- both urls now ask what the version actually published, using the same public_root check theme_css_urls uses
- versions with a minified build are unaffected
- the two url specs shared one set of examples, and now cover the live-build early return too

Versions publishing plain bundles only: 0.0.1 through 2.3.7. Versions publishing minified: 3.0.0 through 3.2.0 and latest.

bundle exec rspec spec/lib/framework/version_spec.rb and the three framework_docs request specs pass, rubocop and bin/check-em-dashes clean.