### PR TITLE
Serve the docs chrome off the engine, not the host pipeline

### DIFF
--- a/app/helpers/framework_helper.rb
+++ b/app/helpers/framework_helper.rb
@@ -1136,12 +1136,34 @@ module FrameworkHelper
     'plugins_legacy.css' => 'plugins_legacy.css'
   }.freeze
 
+  # The docs chrome, which a host's own pipeline answers with a different file.
+  # `asset_path` matches on the logical name across the whole load path, so the first
+  # asset called tailwind.css wins, and on any host that runs Tailwind that is the
+  # host's bundle. The docs then rendered against a stylesheet compiled without these
+  # views in its @source list, and every utility only the docs use was simply absent:
+  # no pt-11 under the fixed nav, no sticky sidebar offset, no border-separate on the
+  # tables. The Prism theme collides the same way on a host carrying its own copy.
+  #
+  # These two come off the engine tree instead. Framework::Static resolves the chrome to
+  # the live build in this repo and the packaged snapshot everywhere else, so the docs
+  # server still serves what it just compiled. Everything else keeps the lookup above:
+  # engine-only paths cannot collide, and the plugin bundles are resolved by serving
+  # mode, where a consumer host that opts in with the development marker is asking for
+  # its own build.
+  HOST_SHADOWED_DOCS_ASSETS = %w[tailwind.css prism_trmnl.css].freeze
+
   # Above the private section on purpose: the controller resolves the docs bundle
   # through `helpers.framework_docs_asset_path`, an explicit receiver, so that the
   # layout tags and the iframe config JSON name one URL.
   def framework_docs_asset_path(logical)
+    return framework_docs_static_path(logical) if HOST_SHADOWED_DOCS_ASSETS.include?(logical)
+
     asset_path(logical)
   rescue Propshaft::MissingAssetError
+    framework_docs_static_path(logical)
+  end
+
+  def framework_docs_static_path(logical)
     public_name = DOCS_PUBLIC_ASSET_MAP.fetch(logical) { File.basename(logical) }
     file = Framework::Static.docs_file_path(public_name)
     # Framework::Static serves these straight off the engine tree, outside Propshaft's

--- a/app/views/layouts/framework.html.erb
+++ b/app/views/layouts/framework.html.erb
@@ -11,8 +11,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;350;375;400;450;600;700&family=EB+Garamond:ital,wght@0,400..800;1,400..800&display=swap" rel="stylesheet">
 
-  <%# Prism.js syntax highlighting for Framework docs code examples - TRMNL theme %>
-  <%= stylesheet_link_tag "prism_trmnl", "data-turbo-track": "reload" %>
+  <%# Prism.js syntax highlighting for Framework docs code examples - TRMNL theme.
+      Resolved like the chrome below rather than by logical name: a host with its own
+      prism_trmnl.css shadows the engine's copy and colors these samples from it. %>
+  <%= stylesheet_link_tag framework_docs_asset_path('prism_trmnl.css'), "data-turbo-track": "reload" %>
   <%= javascript_include_tag "prism-1.29.0.min" %>
 
   <%= javascript_importmap_tags %>

--- a/spec/requests/framework_engine_host_spec.rb
+++ b/spec/requests/framework_engine_host_spec.rb
@@ -53,6 +53,40 @@ RSpec.describe 'Engine host contract' do
         expect(response).to have_http_status(:ok)
       end
     end
+
+    # tailwind.css is the name every Rails app that runs Tailwind builds for itself, and
+    # `asset_path` matches on the logical name across the host's whole load path, so the
+    # host's bundle answered for the chrome. That bundle never had these views in its
+    # @source list, so the docs lost every utility only they use: the nav sat on top of
+    # the content with no pt-11, the sidebars had no sticky offset, and the tables came
+    # out unstyled. This host builds a tailwind.css of its own, which is exactly the
+    # shape that hid the bug.
+    it 'links the engine copy rather than a host asset of the same name', type: :request do
+      get '/framework'
+      href = response.body[/<link[^>]+href="([^"]*tailwind[^"]*)"/, 1]
+
+      get href
+
+      aggregate_failures do
+        expect(href).to start_with('/framework-docs/tailwind.css')
+        expect(response.body).to include('.pt-11{')
+      end
+    end
+
+    # Same collision, one stylesheet over: core carries its own prism_trmnl.css, and the
+    # docs code samples were highlighted from it rather than from the theme this repo
+    # ships next to them.
+    it 'links the engine copy of the Prism theme', type: :request do
+      get '/framework'
+      href = response.body[/<link[^>]+href="([^"]*prism_trmnl[^"]*)"/, 1]
+
+      get href
+
+      aggregate_failures do
+        expect(href).to start_with('/framework-docs/prism_trmnl.css')
+        expect(response).to have_http_status(:ok)
+      end
+    end
   end
 
   # Same contract, one bundle over: every build path compiles plugins_legacy.css, the

--- a/spec/support/framework_build.rb
+++ b/spec/support/framework_build.rb
@@ -89,11 +89,12 @@ module FrameworkBuild
       @plugins_css ||= Rails.root.join(PLUGINS_CSS).read.freeze
     end
 
-    # The docs layout links tailwind.css, so Propshaft raises MissingAssetError
-    # without it. The variant collision guard also reads it, so presence alone is no
-    # longer the contract: a bundle built before a demo picked up a new variant class
-    # would let the guard pass on output the app no longer serves. Same digest stamp
-    # the Sass side uses, over the entry stylesheet and the trees it scans.
+    # The docs chrome the layout links, served off the engine tree, so a docs request
+    # spec that never built it grades the packaged snapshot instead of this checkout.
+    # The variant collision guard also reads it, so presence alone is no longer the
+    # contract: a bundle built before a demo picked up a new variant class would let
+    # the guard pass on output the app no longer serves. Same digest stamp the Sass
+    # side uses, over the entry stylesheet and the trees it scans.
     def tailwind!
       return if @tailwind_built
 


### PR DESCRIPTION
The docs layout resolved its chrome with `framework_docs_asset_path('tailwind.css')`, which asks `asset_path` first and only falls back to the packaged snapshot on `Propshaft::MissingAssetError`. Propshaft matches on the logical name across the host's whole load path, and every Rails app that runs Tailwind builds an asset called `tailwind.css`. So on a host mounting the engine the lookup succeeded and the docs linked the host's bundle instead of their own.

That bundle never had these views in its `@source` list, so the docs lost every utility only they use:

| class | host bundle | framework chrome | symptom |
| --- | --- | --- | --- |
| `pt-11` | absent | present | nav bar sits on top of the content |
| `top-11`, `h-[calc(100vh-2.75rem)]` | absent | present | sidebars have no bounded height left to scroll |
| `border-separate`, `border-spacing-0` | absent | present | docs tables render unstyled |

`app/assets/static/docs_chrome.css` was current the whole time (byte-identical to a fresh build) and simply never reached a page. `prism_trmnl.css` collides the same way on a host carrying its own copy, which colored the code samples from a stale theme.

## Change

`tailwind.css` and `prism_trmnl.css` resolve through `Framework::Static`, which already picks the live build in this repo and the packaged copy everywhere else. Named in `HOST_SHADOWED_DOCS_ASSETS` so the reason travels with the list.

The plugin bundles deliberately stay on the `asset_path` lookup: those are resolved by serving mode, where a consumer host that writes the development marker is asking for its own build.

## Verification

- Two regression examples in `spec/requests/framework_engine_host_spec.rb` assert the href is the engine copy and that the served bytes carry `.pt-11{`. Both fail without the change, since this repo's own host builds a `tailwind.css` and is exactly the shape that hid the bug.
- Live render on a docs server: layout `padding-top: 44px`, sidebar `top: 44px` / `height: 676px` with `scrollHeight 3244 > clientHeight 676`, tables `border-collapse: separate; border-spacing: 0`, no horizontal overflow. The `LIVE BUILD` badge still shows, so the dev live-build path is unchanged.
- `spec/requests`, `spec/helpers` and the chrome staleness spec: 298 examples, 0 failures. The snapshot needed no regeneration.

Unrelated and pre-existing: `spec/requests/framework_precompressed_serving_spec.rb:199` fails on a fresh clone with `uninitialized constant Brotli` (the gem is `require: false` and the spec never requires it). Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
