### PR TITLE
Require brotli in the precompressed serving spec

### DIFF
--- a/spec/requests/framework_precompressed_serving_spec.rb
+++ b/spec/requests/framework_precompressed_serving_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'brotli'
 require 'fileutils'
 require 'rack/mock'
 require 'tmpdir'


### PR DESCRIPTION
`spec/requests/framework_precompressed_serving_spec.rb` fails on a fresh clone with `NameError: uninitialized constant Brotli`, from the released-bundles example that inflates the committed `.br` sibling.

The gem is build-only tooling declared `require: false` in the Gemfile, so nothing autoloads the constant. The spec required only `rails_helper`, `fileutils`, `rack/mock` and `tmpdir`, and passed before solely because another spec that requires brotli happened to load first in a full run. Running the file alone exposes it.

The fix loads it the way the specs that already touch brotli do, next to `rails_helper`: `spec/lib/framework/released_bundles_spec.rb` and `spec/lib/framework/release_task_spec.rb` both require it directly, and `lib/framework/release_task.rb` requires it lazily at its use site. No production code changes.

```
bundle exec rspec spec/requests/framework_precompressed_serving_spec.rb
16 examples, 0 failures
```

Rubocop clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)