### PR TITLE
Stop renders crashing when a deploy replaces the gem directory

### DIFF
--- a/lib/framework/color_data.rb
+++ b/lib/framework/color_data.rb
@@ -12,9 +12,8 @@ module Framework
       end
     end
 
-    def self.load
-      YAML.load_file(yaml_path) || {}
-    end
+    def self.load = @data ||= (YAML.load_file(yaml_path) || {}).freeze
+    def self.reload! = @data = nil
 
     def self.color_palette
       load['color_palette'] || {}

--- a/lib/framework/version.rb
+++ b/lib/framework/version.rb
@@ -17,7 +17,8 @@ module Framework
       Framework.data_root.join("db/data/framework_versions.yml")
     end
 
-    def self.config = YAML.load_file(config_path).freeze
+    def self.config = @config ||= YAML.load_file(config_path).freeze
+    def self.reload! = @config = nil
     def self.version_numbers = config['versions'].map { |v| v['number'] }.freeze
 
     # returns a format compatible with 'select' plugin field type

--- a/lib/framework/version.rb
+++ b/lib/framework/version.rb
@@ -18,8 +18,12 @@ module Framework
     end
 
     def self.config = @config ||= YAML.load_file(config_path).freeze
-    def self.reload! = @config = nil
-    def self.version_numbers = config['versions'].map { |v| v['number'] }.freeze
+    def self.version_numbers = @version_numbers ||= config['versions'].map { |v| v['number'] }.freeze
+
+    def self.reload!
+      @config = nil
+      @version_numbers = nil
+    end
 
     # returns a format compatible with 'select' plugin field type
     def self.options

--- a/spec/lib/framework/color_data_spec.rb
+++ b/spec/lib/framework/color_data_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Framework::ColorData do
+  subject(:color_data) { described_class }
+
+  let(:missing_path) { Framework.data_root.join('db/data/no_such_file.yml') }
+
+  after { color_data.reload! }
+
+  describe '.load' do
+    it 'reads the framework colors data file' do
+      expect(color_data.load).to include('color_palette', 'color_hues')
+    end
+
+    it 'reuses the parsed data rather than re-reading the file' do
+      expect(color_data.load).to be(color_data.load)
+    end
+
+    context 'when a deploy removes the data file after the first read' do
+      before do
+        color_data.load
+        allow(color_data).to receive(:yaml_path).and_return(missing_path)
+      end
+
+      it 'keeps serving the data it already parsed' do
+        expect(color_data.load).to include('color_palette')
+      end
+    end
+  end
+
+  describe '.reload!' do
+    it 'drops the memoized data so the next read re-parses the file' do
+      original = color_data.load
+      color_data.reload!
+      expect(color_data.load).not_to be(original)
+    end
+  end
+end

--- a/spec/lib/framework/version_spec.rb
+++ b/spec/lib/framework/version_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'tmpdir'
 
 RSpec.describe Framework::Version do
   subject(:version) { described_class.new(number) }
@@ -10,17 +9,42 @@ RSpec.describe Framework::Version do
   let(:number) { '1.0.0' }
 
   describe '.config' do
+    let(:missing_path) { Framework.data_root.join('db/data/no_such_file.yml') }
+
+    after { described_class.reload! }
+
     it 'reads the framework versions data file' do
       expect(described_class.config).to include('latest', 'versions')
     end
 
     context 'when the versions data file is missing' do
-      it 'raises rather than returning empty configuration' do
-        Dir.mktmpdir do |dir|
-          allow(described_class).to receive(:config_path).and_return(Pathname.new(dir).join('missing.yml'))
-          expect { described_class.config }.to raise_error(Errno::ENOENT)
-        end
+      before do
+        described_class.reload!
+        allow(described_class).to receive(:config_path).and_return(missing_path)
       end
+
+      it 'raises rather than returning empty configuration' do
+        expect { described_class.config }.to raise_error(Errno::ENOENT)
+      end
+    end
+
+    context 'when a deploy removes the data file after the first read' do
+      before do
+        described_class.config
+        allow(described_class).to receive(:config_path).and_return(missing_path)
+      end
+
+      it 'keeps serving the configuration it already parsed' do
+        expect(described_class.config).to include('latest', 'versions')
+      end
+    end
+  end
+
+  describe '.reload!' do
+    it 'drops the memoized configuration so the next read re-parses the file' do
+      original = described_class.config
+      described_class.reload!
+      expect(described_class.config).not_to be(original)
     end
   end
 

--- a/spec/lib/framework/version_spec.rb
+++ b/spec/lib/framework/version_spec.rb
@@ -46,11 +46,23 @@ RSpec.describe Framework::Version do
       described_class.reload!
       expect(described_class.config).not_to be(original)
     end
+
+    it 'drops the memoized version numbers so the next read rebuilds them' do
+      original = described_class.version_numbers
+      described_class.reload!
+      expect(described_class.version_numbers).not_to be(original)
+    end
   end
 
   describe '.version_numbers' do
+    after { described_class.reload! }
+
     it 'lists every released version as a semantic-version string' do
       expect(described_class.version_numbers).to all(match(/\A\d+\.\d+\.\d+\z/))
+    end
+
+    it 'reuses the built list rather than rebuilding it' do
+      expect(described_class.version_numbers).to be(described_class.version_numbers)
     end
   end
 


### PR DESCRIPTION
Renders crashed for about two minutes after the deploy on 2026-08-04 — 1,512 of them across roughly 1,500 plugin settings on workers 02 and 04, each one an error screen on a real device:

```
No such file or directory @ rb_check_realpath_internal -
  .../bundler/gems/trmnl-framework-4fd57489576e/db/data/framework_versions.yml
```

The gem is installed from git, so bundler names its directory after the resolved commit and removes the previous one on every install. Sidekiq processes that outlive the swap keep resolving paths into the directory that just went away. Prod was serving b05a845 (#6) while every error named 4fd5748 (#5).

`Framework::Version.config` re-read `framework_versions.yml` on every call, and `.latest`, `.new` and `.version_numbers` all go through it, so it runs several times per render. `Fonts`, `Devices` and `Colors` already load their manifests once and expose `reload!` to drop them.

- memoizes `Version.config` and `Version.version_numbers`
- memoizes `ColorData.load`, which re-read `framework_colors.yml` on every call across its eleven accessors, so building one color manifest parsed the same file ten times
- adds `reload!` to both, matching `Devices.reload!` and `Fonts#reload!`
- covers the deploy case with specs, and resets memoization around the existing missing-file example

Verified by deleting both data files from a live `rails runner` process: unpatched raises `Errno::ENOENT`, patched keeps resolving `latest`, `version_numbers`, `color_hues` and `limited_palettes`. Full suite green at 834 examples.