### PR TITLE
fixed docs redirects shadowing `image_url` helper

### DIFF
--- a/config/routes/framework.rb
+++ b/config/routes/framework.rb
@@ -56,7 +56,7 @@ scope :framework do
 
     # Compatibility redirects for older non-versioned docs URLs
     framework_docs_components.each do |component|
-      get "/#{component}", to: redirect("/framework/docs/#{current_docs_version}/#{component}")
+      get "/#{component}", to: redirect("/framework/docs/#{current_docs_version}/#{component}"), as: "framework_docs_#{component}_redirect"
     end
 
     legacy_framework_docs_versions.each do |legacy_version, canonical_version|
@@ -65,7 +65,7 @@ scope :framework do
 
       framework_docs_components.each do |component|
         canonical_component = legacy_version == 'v3' && component == 'text' ? 'text_color' : component
-        get "/#{legacy_version}/#{component}", to: redirect("/framework/docs/#{canonical_version}/#{canonical_component}")
+        get "/#{legacy_version}/#{component}", to: redirect("/framework/docs/#{canonical_version}/#{canonical_component}"), as: "framework_docs_alias_#{legacy_version}_#{component}_redirect"
       end
     end
 
@@ -88,7 +88,7 @@ scope :framework do
 
   # Legacy redirects: /framework/:page -> current docs page
   framework_docs_components.each do |component|
-    get "/#{component}", to: redirect("/framework/docs/#{current_docs_version}/#{component}")
+    get "/#{component}", to: redirect("/framework/docs/#{current_docs_version}/#{component}"), as: "framework_#{component}_redirect"
   end
 
   get "/font_utilities", to: redirect("/framework/docs/text_size")

--- a/spec/requests/framework_docs_routing_spec.rb
+++ b/spec/requests/framework_docs_routing_spec.rb
@@ -64,4 +64,13 @@ RSpec.describe 'Docs routing versions' do
 
     expect(shadowed).to be_empty, "shadowed by an earlier route: #{shadowed.map { |verb, path| "#{verb} #{path}" }.join(', ')}"
   end
+
+  it 'claims no route name that shadows a view helper' do
+    view_helpers = ActionView::Base.instance_methods
+    shadowed = Rails.application.routes.named_routes.names.select do |name|
+      view_helpers.include?(:"#{name}_path") || view_helpers.include?(:"#{name}_url")
+    end
+
+    expect(shadowed).to be_empty, "route names shadowing a view helper: #{shadowed.join(', ')}"
+  end
 end


### PR DESCRIPTION
## What and why

Framework redirect took precedence over native `image_url` helper. This PR fixes that by naming the redirect.

## Checklist

- [X] `bundle exec rspec` passes (the Ruby suite, behind the required `RSpec` check).
- [X] `bundle exec rubocop` passes.
- [X] `npm run test:stylesheets`, `npm run test:scripts` and `npm run test:rulediff` pass.
- [X] `bin/build` succeeds (no undefined Sass references).
- [X] `bin/check-em-dashes` passes, and no em-dashes in any docs copy or comments I touched.
- [X] Generated files regenerated and committed if their sources moved: `rake
      framework:colors`, `rake framework:docs_chrome`, `rake framework:legacy_bundle`.
- [X] Docs updated: if a utility or API changed, its docs page and live example were
      updated in this PR.
- [X] Rendering change: `npm run test:runtime` and `npm run test:visual` run locally, with
      any intentional baseline updates committed.
- [X] Change is small and focused (one concern).
