### PR TITLE
Let plugin markup repaint --framework-stroke-contrast again

### DIFF
--- a/app/assets/stylesheets/framework/base/_title_bar.scss
+++ b/app/assets/stylesheets/framework/base/_title_bar.scss
@@ -44,7 +44,7 @@
             &:not([data-adaptive]) {
                 @include _title-bar-image-stroke(
                     calc(var(--title-bar-text-stroke-width) * 0.5),
-                    var(--framework-semantic-stroke-contrast-stroke-color, var(--framework-stroke-contrast))
+                    mixins.contrast-stroke-color()
                 );
             }
         }
@@ -61,7 +61,7 @@
             align-items: center;
             @include _title-bar-image-stroke(
                 calc(var(--title-bar-text-stroke-width) * 0.5),
-                var(--framework-semantic-stroke-contrast-stroke-color, var(--framework-stroke-contrast))
+                mixins.contrast-stroke-color()
             );
         }
 
@@ -80,7 +80,7 @@
             background-image: var(--framework-semantic-text-primary-text-image, none);
             -webkit-background-clip: var(--framework-semantic-text-primary-text-clip, border-box);
             background-clip: var(--framework-semantic-text-primary-text-clip, border-box);
-            @include mixins.shadow-text-stroke(var(--title-bar-text-stroke-width), var(--framework-semantic-stroke-contrast-stroke-color, var(--framework-stroke-contrast)), calc(var(--title-bar-text-stroke-width) * 0.5));
+            @include mixins.shadow-text-stroke(var(--title-bar-text-stroke-width), mixins.contrast-stroke-color(), calc(var(--title-bar-text-stroke-width) * 0.5));
         }
 
         .instance {
@@ -101,7 +101,7 @@
             background-image: var(--framework-semantic-text-primary-text-image, none);
             -webkit-background-clip: var(--framework-semantic-text-primary-text-clip, border-box);
             background-clip: var(--framework-semantic-text-primary-text-clip, border-box);
-            @include mixins.shadow-text-stroke(var(--title-bar-text-stroke-width), var(--framework-semantic-stroke-contrast-stroke-color, var(--framework-stroke-contrast)), calc(var(--title-bar-text-stroke-width) * 0.5));
+            @include mixins.shadow-text-stroke(var(--title-bar-text-stroke-width), mixins.contrast-stroke-color(), calc(var(--title-bar-text-stroke-width) * 0.5));
         }
     }
 

--- a/app/assets/stylesheets/framework/components/_item-device.scss
+++ b/app/assets/stylesheets/framework/components/_item-device.scss
@@ -93,7 +93,7 @@
 
             .index {
                 @include mixins.for-screen-modifier('2bit', '4bit') {
-                    @include mixins.shadow-text-stroke(vars.ui-scaled(2px), var(--framework-semantic-stroke-contrast-stroke-color, var(--framework-stroke-contrast)), vars.ui-scaled(1px));
+                    @include mixins.shadow-text-stroke(vars.ui-scaled(2px), mixins.contrast-stroke-color(), vars.ui-scaled(1px));
                     font-family: var(--item-index-font-family);
                     font-weight: var(--item-index-font-weight);
                     -webkit-font-smoothing: var(--item-index-font-smoothing);

--- a/app/assets/stylesheets/framework/components/_item.scss
+++ b/app/assets/stylesheets/framework/components/_item.scss
@@ -60,7 +60,7 @@
             border-radius: vars.ui-scaled(3px);
 
             .index {
-                @include mixins.shadow-text-stroke(vars.ui-scaled(3.5px), var(--framework-semantic-stroke-contrast-stroke-color, var(--framework-stroke-contrast)), vars.ui-scaled(1.75px));
+                @include mixins.shadow-text-stroke(vars.ui-scaled(3.5px), mixins.contrast-stroke-color(), vars.ui-scaled(1.75px));
                 @include mixins.semantic-text-paint('text-primary', var(--framework-text-primary));
                 overflow: visible;
                 font-family: var(--item-index-font-family);

--- a/app/assets/stylesheets/framework/components/_table-device.scss
+++ b/app/assets/stylesheets/framework/components/_table-device.scss
@@ -33,7 +33,7 @@
 
         @include mixins.for-screen-modifier('2bit', '4bit') {
             tbody tr td .meta .index {
-                @include mixins.shadow-text-stroke(vars.ui-scaled(2px), var(--framework-semantic-stroke-contrast-stroke-color, var(--framework-stroke-contrast)), vars.ui-scaled(1px));
+                @include mixins.shadow-text-stroke(vars.ui-scaled(2px), mixins.contrast-stroke-color(), vars.ui-scaled(1px));
                 font-family: var(--item-index-font-family);
                 font-weight: var(--item-index-font-weight);
                 -webkit-font-smoothing: var(--item-index-font-smoothing);

--- a/app/assets/stylesheets/framework/components/_table.scss
+++ b/app/assets/stylesheets/framework/components/_table.scss
@@ -135,7 +135,7 @@
                     transform: translateX(-50%);
 
                     .index {
-                        @include mixins.shadow-text-stroke(vars.ui-scaled(3.5px), var(--framework-semantic-stroke-contrast-stroke-color, var(--framework-stroke-contrast)), vars.ui-scaled(1.75px));
+                        @include mixins.shadow-text-stroke(vars.ui-scaled(3.5px), mixins.contrast-stroke-color(), vars.ui-scaled(1.75px));
                         @include mixins.semantic-text-paint('text-primary', var(--framework-text-primary));
                         overflow: visible;
                         font-family: var(--item-index-font-family);

--- a/app/assets/stylesheets/framework/mixins/_shadow-text-stroke.scss
+++ b/app/assets/stylesheets/framework/mixins/_shadow-text-stroke.scss
@@ -10,6 +10,7 @@
 @use 'sass:list';
 @use 'sass:string';
 @use 'utilities' as utilities;
+@use 'stroke-tokens' as stroke-tokens;
 
 @function _shadow-stroke-layer($radius-scale, $x, $y) {
     $scaled-x: $radius-scale * $x;
@@ -45,7 +46,7 @@
 
 @mixin shadow-text-stroke(
     $width: 3.5px,
-    $color: var(--framework-semantic-stroke-contrast-stroke-color, var(--framework-stroke-contrast)),
+    $color: stroke-tokens.contrast-stroke-color(),
     // Native strokes were center-aligned (half the width painted outside the
     // glyph), so visual parity needs radius = width/2.
     $radius: clamp(0.85px, calc(#{$width} * 0.5), 3.75px)

--- a/app/assets/stylesheets/framework/mixins/_stroke-tokens.scss
+++ b/app/assets/stylesheets/framework/mixins/_stroke-tokens.scss
@@ -22,6 +22,12 @@ $stroke-sizes: ('base', 'small', 'medium', 'large', 'xlarge');
     @return $items;
 }
 
+// --framework-stroke-contrast leads the chain: plugin markup repaints that name, and
+// an override below the screen never reaches the semantic one (stroke-contrast-override.spec.js).
+@function contrast-stroke-color() {
+    @return var(--framework-stroke-contrast, var(--framework-semantic-stroke-contrast-stroke-color));
+}
+
 // Every color token a stroke modifier can name, in emission order. The two
 // shade palettes share black and white, so the list is deduped by name.
 @function stroke-token-names() {

--- a/app/assets/stylesheets/framework/mixins/_theme-slots.scss
+++ b/app/assets/stylesheets/framework/mixins/_theme-slots.scss
@@ -118,6 +118,11 @@ $chart-series-slots: 16;
     } @else {
         --framework-semantic-#{$semantic}-stroke-color: var(--stroke-#{$token}-color, var(--#{$token}, #{$fallback}));
     }
+
+    // Republish the alias in the same scope: contrast-stroke-color() reads it first.
+    @if $semantic == 'stroke-contrast' {
+        --framework-stroke-contrast: var(--framework-semantic-stroke-contrast-stroke-color);
+    }
 }
 
 @mixin semantic-border($semantic, $token, $fallback: transparent, $raw: false) {

--- a/app/assets/stylesheets/framework/utilities/_image_stroke.scss
+++ b/app/assets/stylesheets/framework/utilities/_image_stroke.scss
@@ -30,7 +30,7 @@ $image-stroke-sizes: (
 
 @mixin image-stroke-default-vars {
     --tn-image-stroke-width: #{vars.content-scaled(1.5px)};
-    --tn-image-stroke-color: var(--framework-semantic-stroke-contrast-stroke-color, var(--framework-stroke-contrast));
+    --tn-image-stroke-color: #{mixins.contrast-stroke-color()};
 }
 
 // Four corner shadows at the bound offset. Long filter chains are expensive, so
@@ -38,7 +38,7 @@ $image-stroke-sizes: (
 @mixin image-stroke-apply-from-vars {
     $offset: var(--tn-image-stroke-width, 1.5px);
     $back: calc(var(--tn-image-stroke-width, 1.5px) * -1);
-    $color: var(--tn-image-stroke-color, var(--framework-semantic-stroke-contrast-stroke-color, var(--framework-stroke-contrast)));
+    $color: var(--tn-image-stroke-color, #{mixins.contrast-stroke-color()});
 
     --tn-image-stroke: drop-shadow(#{$offset} #{$offset} 0 #{$color}) drop-shadow(#{$back} #{$back} 0 #{$color}) drop-shadow(#{$back} #{$offset} 0 #{$color}) drop-shadow(#{$offset} #{$back} 0 #{$color});
     @include mixins.filter-from-vars;

--- a/app/assets/stylesheets/framework/utilities/_text_stroke.scss
+++ b/app/assets/stylesheets/framework/utilities/_text_stroke.scss
@@ -25,13 +25,13 @@ $text-stroke-sizes: (
 @mixin text-stroke-default-vars {
     --tn-text-stroke-width: #{vars.content-scaled(3.5px)};
     --tn-text-stroke-radius: #{vars.content-scaled(1.75px)};
-    --tn-text-stroke-color: var(--framework-semantic-stroke-contrast-stroke-color, var(--framework-stroke-contrast));
+    --tn-text-stroke-color: #{mixins.contrast-stroke-color()};
 }
 
 @mixin text-stroke-apply-from-vars {
     @include mixins.shadow-text-stroke(
         var(--tn-text-stroke-width, 3.5px),
-        var(--tn-text-stroke-color, var(--framework-semantic-stroke-contrast-stroke-color, var(--framework-stroke-contrast))),
+        var(--tn-text-stroke-color, #{mixins.contrast-stroke-color()}),
         var(--tn-text-stroke-radius, clamp(0.85px, calc(var(--tn-text-stroke-width, 3.5px) * 0.5), 3.75px))
     );
 }

--- a/test/runtime/framework/stroke-contrast-override.spec.js
+++ b/test/runtime/framework/stroke-contrast-override.spec.js
@@ -1,0 +1,87 @@
+import { expect, test } from '@playwright/test';
+import { frameworkBundleFile, readBuild } from '../../support/processed-bundle.js';
+
+// Custom properties substitute in their declaring scope, so only a browser proves
+// override reachability: a runtime spec, not a compiled-CSS one.
+const OVERRIDE_CSS = `
+  .pill {
+    --framework-stroke-contrast: #000000;
+    color: var(--framework-text-inverse);
+  }
+`;
+
+async function routeStylesheets(page) {
+  const bundle = await readBuild(frameworkBundleFile());
+  await page.route('**/__stroke-contrast__/plugins.css', (route) => route.fulfill({
+    body: bundle,
+    contentType: 'text/css',
+  }));
+
+  const theme = await readBuild('themes/dark-theme.css');
+  await page.route('**/__stroke-contrast__/dark-theme.css', (route) => route.fulfill({
+    body: theme,
+    contentType: 'text/css',
+  }));
+}
+
+async function renderScreen(page, { themed }) {
+  const themeLink = themed
+    ? '<link rel="stylesheet" href="/__stroke-contrast__/dark-theme.css">'
+    : '';
+  const themeClass = themed ? ' screen--theme-dark' : '';
+
+  await page.setContent(`<!DOCTYPE html><html><head><meta charset="utf-8">
+      <link rel="stylesheet" href="/__stroke-contrast__/plugins.css">${themeLink}
+      <style>html, body { margin: 0 } .screen { visibility: visible } ${OVERRIDE_CSS}</style>
+    </head><body class="environment trmnl">
+      <div class="screen screen--og screen--1bit${themeClass}">
+        <span data-probe="default" class="text-stroke">93</span>
+        <div class="pill"><span data-probe="override" class="text-stroke">82</span></div>
+        <div class="inverse"><span data-probe="inverse" class="text-stroke">72</span></div>
+      </div>
+    </body></html>`);
+  await page.evaluate(() => document.fonts.ready);
+
+  return page.evaluate(() => Object.fromEntries(
+    [...document.querySelectorAll('[data-probe]')].map((element) => {
+      const style = getComputedStyle(element);
+      return [element.dataset.probe, {
+        strokeColor: style.getPropertyValue('--tn-text-stroke-color').trim(),
+        ring: (style.textShadow.match(/^rgba?\([^)]+\)/) || [''])[0],
+      }];
+    })
+  ));
+}
+
+test.describe('stroke contrast override', () => {
+  test.beforeEach(async ({ page }) => {
+    await routeStylesheets(page);
+    // setContent alone leaves the page on about:blank, where the routed
+    // absolute stylesheet paths never resolve.
+    await page.goto('/framework/test/runtime');
+  });
+
+  test('a subtree repainting --framework-stroke-contrast strokes with its own color', async ({ page }) => {
+    const probes = await renderScreen(page, { themed: false });
+
+    expect(probes.override).toEqual({ strokeColor: '#000000', ring: 'rgb(0, 0, 0)' });
+  });
+
+  test('an untouched screen still strokes with the semantic contrast color', async ({ page }) => {
+    const probes = await renderScreen(page, { themed: false });
+
+    expect(probes.default).toEqual({ strokeColor: '#FFFFFF', ring: 'rgb(255, 255, 255)' });
+  });
+
+  test('a theme still moves the stroke color on the screen it themes', async ({ page }) => {
+    const probes = await renderScreen(page, { themed: true });
+
+    expect(probes.default).toEqual({ strokeColor: '#000000', ring: 'rgb(0, 0, 0)' });
+  });
+
+  test('a theme still moves the stroke color in scopes below the screen', async ({ page }) => {
+    const probes = await renderScreen(page, { themed: true });
+
+    expect(probes.inverse).toEqual({ strokeColor: '#FFFFFF', ring: 'rgb(255, 255, 255)' });
+  });
+});


### PR DESCRIPTION
A Weather Glance render came back with white blobs where the temperatures should be. The recipe does what recipes have always done to keep white-on-dark text legible:

```css
.wxgv2-pill.bg--inverted { --framework-stroke-contrast: #000000; }
```

Since 3.2.0 that has no effect. Stroke consumers resolve their color as `var(--framework-semantic-stroke-contrast-stroke-color, var(--framework-stroke-contrast))`, and the semantic channel is always defined at the root, so the second name is unreachable. The recipe's black stroke stays white, and white text under a white ring is a blob. Measured on the pinned 3.2.0 bundle:

| | 3.1.x | 3.2.0 | this branch |
|---|---|---|---|
| `--framework-stroke-contrast` on the element | `#000000` | `#000000` | `#000000` |
| `--tn-text-stroke-color` (what paints) | `#000000` | **`#FFFFFF`** | `#000000` |

Reading the alias first is not enough on its own, and that is the part worth reviewing. A custom property substitutes in the scope that declares it, so a chain led by the semantic name computes once on the screen element and a subtree override can never reach it, no matter how the fallbacks are nested. Meanwhile a theme moves that channel twice: on the screen for its base scope, and again on `.inverse` below it. Deriving one name from the other in `:root` fixes neither case (verified in a browser before picking this shape).

So:

- adds `contrast-stroke-color()` in `mixins/_stroke-tokens.scss`, the one chain every stroke consumer now reads, alias first
- republishes `--framework-stroke-contrast` from `semantic-stroke()` so it tracks the semantic value in every scope that moves it, `.inverse` included
- replaces the chain at 13 call sites across 6 files, so the next change to it is one line

## What this does not do

The bug's twin is on the core side: a calendar view passed the same always-defined channel into an inline `-webkit-text-stroke` and erased its own event text. Fixed separately in usetrmnl/core#4122, since nothing in the framework could repair it.

No version bump here. Releases are maintainer-only per CONTRIBUTING.

The compatibility only extends to markup that sets the alias. Anything that set a `--framework-semantic-*` channel directly in a subtree, without its alias, is unaffected by this change and still reads at screen level (TODO: no known consumer does this, but it is not enforced anywhere).

## Verification

`bundle exec rspec` (834 examples), `npm run test:runtime` (89), `npm run test:visual` (46 baselines unchanged), both node contract suites, `bundle exec rubocop` (128 files), `bin/check-em-dashes`, `bin/build`: all green.

`test/runtime/framework/stroke-contrast-override.spec.js` is new and runs in a real engine, because computed-value-time scoping is the whole question and compiled-CSS text cannot answer it. Four cases: subtree override wins, an untouched screen is unchanged, a theme still wins on the screen it themes, and a theme still wins in `.inverse` below it. On `main` exactly one of the four fails (the override case) and the three theme/default invariants pass, which is the shape you want from a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
