### PR TITLE
Added the way to put a pattern on a fill to the docs

### DIFF
--- a/app/views/framework/text_color.html.erb
+++ b/app/views/framework/text_color.html.erb
@@ -325,6 +325,29 @@
         </div>
       </section>
 
+      <section class="space-y-8">
+        <div class="space-y-4">
+          <%= framework_heading(3, 'Patterned ink on a filled element') %>
+          <p class="<%= framework_section_description_classes %>">
+            On a screen with no true gray, a gray shade is painted through the shape of the glyphs
+            rather than as a color. An element has one background, and only one of these can use
+            it, so a patterned ink and a <code class="<%= framework_section_code_classes %>">bg--{shade}</code>
+            fill cannot sit on the same element. Put the fill on the box and the ink on an element
+            inside it, which black and white never need because they are real colors.
+          </p>
+        </div>
+
+        <div class="mt-4">
+          <%= render CodeExampleComponent.new(
+            demo_code: '<!-- Both want the one background -->
+<div class="bg--white text--gray-50">Mon 8/3</div>
+
+<!-- Fill on the box, ink on an element inside it -->
+<div class="bg--white"><span class="text--gray-50">Mon 8/3</span></div>'
+          ) %>
+        </div>
+      </section>
+
       <%= render 'framework/page_navigation' %>
     </div>
   </div>

--- a/test/release/legacy-bundle-paint.spec.js
+++ b/test/release/legacy-bundle-paint.spec.js
@@ -1,40 +1,33 @@
 import { expect, test } from '@playwright/test';
 
-// Every released version whose composed bg--/text-- rule needed re-emitting, plus the one
-// after them as a control. These are frozen bundles, so the list only grows if a release is
-// re-cut with the same fault; the rspec parity spec is what watches for that.
+// The released versions that carry the composed bg--/text-- rule. They are frozen, so this list
+// only grows when a release is cut; the rspec parity spec is what watches the rule's size.
 const VERSIONS = ['3.0.5', '3.1.1', '3.1.2', '3.1.3', '3.1.4', '3.1.5', '3.1.6', '3.1.7', '3.1.8', '3.2.0'];
 
-// One case per family of palette, because they fail differently: a colour palette used to
-// paint the whole element with the ink tile, a tiled greyscale one used to paint nothing.
-// The variant case is the rest of the rule's selector list, which is most of it: the gates
-// are emitted after the plain pair, so they are what a length limit takes first.
+// A palette per family, because each reaches the rule through a different set of tokens, plus a
+// variant-prefixed pair, which is where most of the rule's selectors live.
 const CASES = [
   { name: 'four-colour', screen: 'screen--color-4bwry', bg: 'bg--yellow', text: 'text--black' },
   { name: 'one-bit', screen: 'screen--1bit', bg: 'bg--gray-50', text: 'text--black' },
   { name: 'variant', screen: 'screen--color-4bwry', bg: 'bg--yellow', text: 'sm:text--black' },
 ];
 
-// Two boxes of the same size, one carrying the bg-- utility alone and one carrying it with a
-// text-- utility. Adding a text fill must not change what the box paints, so the pair is the
-// assertion: no baseline files, and it holds for any palette on any platform.
-//
-// The bundle comes from Framework::Static at the path a pinned plugin links, because what
-// failed here was a browser's own reading of that file, which reading it cannot catch.
-async function openProbes(page, version, testCase) {
-  // The host page is served from the suite rather than the app so that only the bundle and
-  // its images cross the wire, but it keeps the server's origin, which is what makes the
-  // bundle's own /images/ URLs resolve.
+// A pattern shade, which is the one kind of text fill that cannot share an element with a bg--
+// fill. The docs send authors here, so it has to keep working.
+const NESTED = { screen: 'screen--color-4bwry', bg: 'bg--yellow', text: 'text--gray-50' };
+
+// The bundle is read over HTTP at the path a pinned plugin links, because what fails here is a
+// browser's own reading of that file. The host page is served by the suite so that only the
+// bundle and its images cross the wire, but it keeps the server's origin, which is what lets the
+// bundle's own /images/ URLs resolve.
+async function openProbePage(page, version, probes) {
   await page.route('**/probe', (route) => route.fulfill({
     contentType: 'text/html',
     body: `
       <link rel="stylesheet" href="/css/${version}/plugins.min.css">
       <body class="environment trmnl" style="margin:0">
-        <div class="screen screen--og_plus ${testCase.screen} screen--lg">
-          <div class="view view--full">
-            <div id="field" class="${testCase.bg}" style="width:200px;height:60px"></div>
-            <div id="composed" class="${testCase.bg} ${testCase.text}" style="width:200px;height:60px"></div>
-          </div>
+        <div class="screen screen--og_plus ${probes.screen} screen--lg">
+          <div class="view view--full">${probes.html}</div>
         </div>
       </body>
     `,
@@ -54,27 +47,60 @@ function paintOf(page, id) {
   }, id);
 }
 
+// Two boxes the same size, one with the bg-- utility alone and one with a text-- utility beside
+// it. Adding a text fill must not change what the box paints, so the pair is the assertion and
+// there are no baseline images to keep per platform.
+function composedProbes(testCase) {
+  const box = 'style="width:200px;height:60px"';
+  return {
+    screen: testCase.screen,
+    html: `<div id="field" class="${testCase.bg}" ${box}></div>
+           <div id="composed" class="${testCase.bg} ${testCase.text}" ${box}></div>`,
+  };
+}
+
+function nestedProbes() {
+  const box = 'style="width:200px;padding:20px 8px"';
+  return {
+    screen: NESTED.screen,
+    html: `<div id="field" class="${NESTED.bg}" ${box}></div>
+           <div id="outer" class="${NESTED.bg}" ${box}><span id="ink" class="${NESTED.text}">Mon 8/3</span></div>`,
+  };
+}
+
 for (const version of VERSIONS) {
   for (const testCase of CASES) {
-    test(`${version} keeps a ${testCase.name} bg-- field under a text-- fill`, async ({ page }) => {
-      await openProbes(page, version, testCase);
+    test(`${version} declares a ${testCase.name} bg-- fill under a text-- fill`, async ({ page }) => {
+      await openProbePage(page, version, composedProbes(testCase));
       const field = await paintOf(page, 'field');
       const composed = await paintOf(page, 'composed');
 
       expect(composed.image).toContain(field.image);
       expect(composed.color).toBe(field.color);
       // Firefox gives every background layer the first value, so anything but border-box here
-      // confines the field to the glyphs there, whatever the rest of the list says.
+      // confines the fill to the glyphs there, whatever the rest of the list says.
       expect(composed.firstClip).toBe('border-box');
     });
 
-    test(`${version} paints a ${testCase.name} bg-- field under a text-- fill`, async ({ page }) => {
-      await openProbes(page, version, testCase);
+    test(`${version} paints a ${testCase.name} bg-- fill under a text-- fill`, async ({ page }) => {
+      await openProbePage(page, version, composedProbes(testCase));
 
-      // Firefox reported the computed values above as correct on a bundle that painted a solid
-      // black box, so the two browsers disagree about which half of this catches a regression.
+      // The declarations above read as correct in Firefox on a bundle it painted wrong, so the
+      // pixels are asserted separately.
       expect(await page.locator('#composed').screenshot())
         .toEqual(await page.locator('#field').screenshot());
     });
   }
+
+  test(`${version} keeps both fills when a pattern shade is nested`, async ({ page }) => {
+    await openProbePage(page, version, nestedProbes());
+    const field = await paintOf(page, 'field');
+    const outer = await paintOf(page, 'outer');
+    const ink = await paintOf(page, 'ink');
+
+    expect(outer.image).toBe(field.image);
+    expect(outer.firstClip).toBe('border-box');
+    // The pattern still clips to the glyphs, because that element paints nothing else.
+    expect(ink.firstClip).toBe('text');
+  });
 }


### PR DESCRIPTION
A gray text shade is painted through the shape of the glyphs, not as a color. An element has one background and only one of them can use it, so a gray shade and a `bg--*` fill cannot sit on the same element. Which one paints depends on the browser: Chromium clips each background layer on its own, Firefox applies one clip to every layer, and the render pool uses Firefox.

Nothing documented what to write instead.

- adds a section to the text color page: put the fill on the box and the ink on an element inside it
- adds that case to `npm run test:release`, so it is covered on every released bundle in Chromium and Firefox
- applies to pattern shades only, `text--black` and `text--white` are real colors

Docs and tests only, no bundle changes. Related to usetrmnl/core#4183.