### PR TITLE
Removed the engine's helpers from host controllers

### DIFF
--- a/app/controllers/framework_controller.rb
+++ b/app/controllers/framework_controller.rb
@@ -10,6 +10,15 @@ class FrameworkController < Framework.parent_controller_class
   # renders core's picker.
   prepend_view_path Framework::Engine.root.join('app/views')
 
+  # Declared last so these answer over a same-named host helper (see Framework::Engine for
+  # why the host gets none of them).
+  helper CoreCompatHelper
+  helper DocsChromeHelper
+  helper FrameworkDemoHelper
+  helper FrameworkHelper
+  helper FrameworkImagesHelper
+  helper FrameworkRoutesHelper
+
   # CONTEXT: docs pages render ~1.5MB of layout-dominated, visitor-independent
   # HTML in 1.1-1.5s, so whole responses are cached and replayed. Declared
   # before the other callbacks so a cache hit skips them (including

--- a/app/controllers/framework_tests_controller.rb
+++ b/app/controllers/framework_tests_controller.rb
@@ -8,8 +8,9 @@ class FrameworkTestsController < Framework.parent_controller_class
 
   layout :test_layout
 
-  helper FrameworkHelper
+  helper CoreCompatHelper
   helper FrameworkDemoHelper
+  helper FrameworkHelper
 
   def overflow; end
   def fonts; end

--- a/docs/ENGINE_INTEGRATION.md
+++ b/docs/ENGINE_INTEGRATION.md
@@ -224,10 +224,13 @@ before mounting:
 
 - **Controllers**: `FrameworkController`, `FrameworkTestsController`.
 - **Helpers**: `FrameworkHelper`, `FrameworkDemoHelper`, `FrameworkImagesHelper`,
-  `FrameworkRoutesHelper`, `DocsChromeHelper`, `CoreCompatHelper`.
-  Rails includes every engine helper in every host view, so the method names are claimed
-  too. `FrameworkRoutesHelper` redefines the framework route helpers that carry no docs
-  version, so a host that renders them keeps its own `default_url_options` off them.
+  `FrameworkRoutesHelper`, `DocsChromeHelper`, `CoreCompatHelper`. The constant names are
+  claimed, the method names are not: the engine hands the host no `app/helpers` path, so
+  `helper :all` never finds these and your controllers, mailers and views keep every method
+  name they define. The two docs controllers include the modules their own pages call, which
+  is the only place engine helpers run. `FrameworkRoutesHelper` redefines the framework route
+  helpers that carry no docs version, and now only inside the docs, so a host page that
+  renders one of them gets the plain Rails helper.
 - **View components**: `AppMenubarComponent`, `CodeExampleComponent`, `DocsRef`,
   `TokensRef`, `FrameworkComparisonComponent`, `FrameworkDocCardComponent`,
   `FrameworkDocsSectionComponent`.

--- a/lib/trmnl/framework/engine.rb
+++ b/lib/trmnl/framework/engine.rb
@@ -25,6 +25,10 @@ module Framework
     config.autoload_paths << root.join("lib")
     config.eager_load_paths << root.join("lib")
 
+    # Keeps these helpers out of the host's `helper :all`, which included them ahead of the
+    # host's own. The `app` glob above still autoloads the modules for the docs controllers.
+    config.paths["app/helpers"] = []
+
     initializer "trmnl_framework.ignore_lib_tooling" do
       Rails.autoloaders.main.ignore(
         root.join("lib/tasks"),

--- a/spec/docs/framework_docs_copy_style_spec.rb
+++ b/spec/docs/framework_docs_copy_style_spec.rb
@@ -101,6 +101,9 @@ RSpec.describe 'Framework docs copy style' do
   end
 
   describe 'docs group descriptions', type: :helper do
+    # The docs controller opts this module in; nothing mixes it into a bare view any more.
+    before { helper.extend(FrameworkHelper) }
+
     it 'describes only groups a supported version actually renders' do
       rendered = FrameworkController::DOC_GROUPS_BY_VERSION.values.flat_map(&:keys).map(&:to_s).uniq
       described = FrameworkController::SUPPORTED_DOCS_VERSIONS.flat_map do |version|

--- a/spec/helpers/framework_helper_spec.rb
+++ b/spec/helpers/framework_helper_spec.rb
@@ -37,6 +37,9 @@ RSpec.describe FrameworkHelper, type: :helper do
     end
 
     it 'renders the font weight intro markup rather than escaping it' do
+      # DocsChromeHelper wraps the paragraph and is not auto-included any more.
+      helper.extend(DocsChromeHelper)
+
       expect(helper.render_framework_intro_paragraph('font_weight')).to include('<code>text--bold</code>')
     end
   end

--- a/spec/requests/framework_engine_host_spec.rb
+++ b/spec/requests/framework_engine_host_spec.rb
@@ -621,7 +621,7 @@ RSpec.describe 'Engine host contract' do
       expect(Framework::MenubarTheme.fetch(:framework).divider).to be_a(String)
     end
 
-    it 'documents every helper it injects' do
+    it 'documents every helper it defines' do
       helpers = Dir.children(Framework::Engine.root.join('app/helpers')).map { |file| File.basename(file, '.rb').camelize }
       undocumented = helpers.reject { |helper| integration_doc.include?(helper) }
 
@@ -633,6 +633,36 @@ RSpec.describe 'Engine host contract' do
       undocumented = roots.reject { |root| integration_doc.include?(root) }
 
       expect(undocumented).to be_empty, "add #{undocumented.join(', ')} to the ENGINE_INTEGRATION.md constant surface list"
+    end
+  end
+
+  # Rails included every engine helper ahead of the host's own, so core's ImagesHelper#sprite_icon
+  # and PluginHelper#plugin_image_path were dead code under ours: production bug #4239.
+  describe 'helpers the host does not get' do
+    let(:engine_helpers) do
+      Dir.children(Framework::Engine.root.join('app/helpers'))
+         .map { |file| File.basename(file, '.rb').camelize.constantize }
+    end
+
+    it 'injects none of them into a host controller' do
+      expect(ApplicationController._helpers.ancestors & engine_helpers).to be_empty
+    end
+
+    it 'opts every one of them in on the docs controller' do
+      expect(FrameworkController._helpers.ancestors).to include(*engine_helpers)
+    end
+
+    it 'opts the test pages in on the helpers their views call' do
+      expect(FrameworkTestsController._helpers.ancestors)
+        .to include(FrameworkHelper, FrameworkDemoHelper, CoreCompatHelper)
+    end
+
+    context 'because the docs need the same-origin copy the gem vendors, not an asset host that 301s without CORS' do
+      it 'keeps its own stand-ins ahead of a host helper of the same name' do
+        ancestors = FrameworkController._helpers.ancestors
+
+        expect(ancestors.index(CoreCompatHelper)).to be < ancestors.index(ApplicationController._helpers)
+      end
     end
   end
 


### PR DESCRIPTION
Rails hands a non-isolated engine's `app/helpers` to the host's `helper :all` ahead of the host's own modules, so every core controller has been answering `sprite_icon` from this gem and `plugin_image_path`/`meta` from stand-ins meant for standalone use. Core's `ImagesHelper` and `PluginHelper` were dead code under ours — that's the collision class behind production bug usetrmnl/core#4239, and it turns out `CoreCompatHelper#meta` has also been shadowing metamagic, so core pages currently emit bare page names as `<title>`/`og:title` instead of `TRMNL | Page name`. This PR makes the engine's helpers opt-in: a host controller gets zero engine helper modules, and the engine's own controllers include them explicitly.

Stacked on #17 (`palette/single-provider`).

- withdraws the engine's `app/helpers` from the host's helper paths (`config.paths["app/helpers"] = []`) — one line; the constants still autoload via the `app/*` Zeitwerk root, and host mailers stop inheriting the modules too
- opts the 6 helper modules in on `FrameworkController` (alphabetical, reproducing the previous precedence order — zero cross-module name collisions, verified programmatically) and `CoreCompatHelper` on `FrameworkTestsController`
- keeps `CoreCompatHelper` unconditional on docs pages, in front of a core-like host's own helpers: its `plugin_image_path` resolves the same-origin copies the gem vendors, where core's points at an asset host that 301s without CORS headers and breaks `image--adaptive` recoloring; pinned by a spec
- states two helper-spec dependencies explicitly (the RSpec view harness no longer auto-mixes engine helpers)
- guards the shape with specs: a plain host controller's `_helpers` include none of the 6 modules; the opt-in list is derived from `Dir.children(app/helpers)` so a 7th helper can't appear without a decision; renames the claimed-surface example to "documents every helper it defines"
- rewrites ENGINE_INTEGRATION.md's Helpers section: constant names claimed, method names not

Evidence: full suite 1020 examples 0 failures; five docs/test pages byte-identical before and after (CSRF token and per-render tooltip ids normalized); standalone server and mounted-in-core browser checks green (docs pages render with 74 palette items and 58/58 sprite symbols; core dashboard regains the `TRMNL | ` title prefix). Core was swept for all 182 public method names across the 6 modules: 41 occur in core and every one resolves to a core-owned definition.

When core bumps the gem, three things change on core's side by design:

- sprite `<symbol>`s keep whatever `width`/`height` core's icon partials carry (core's spec pins that its sprited icons carry none)
- `plugin_image_path` returns to core's own `PluginHelper` (the #4239 direction; core's render preprocessor already handles URL rewriting)
- `meta title:` returns to metamagic — page titles regain the `TRMNL | ` prefix; no core spec pins titles, worth an eyeball on the bump PR

Not solved here: the 181 `shared/icons/*` virtual-path collisions (resolved by `prepend_view_path`, unchanged) and the importmap preload quirks remain follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
