### PR TITLE
Fixed limited palettes leaking theme hues through strokes

### DIFF
--- a/app/assets/stylesheets/framework/base/_screen-mode-vars.scss
+++ b/app/assets/stylesheets/framework/base/_screen-mode-vars.scss
@@ -764,12 +764,33 @@ $_two-bit-tile-families: ('grayscale--2bit', 'grayscale-preview--2bit');
     }
 }
 
-// Preview mode mutes bg/text through the -preview image families; strokes are
-// the only solid-color chain, so remap chromatic tokens to their preview
-// solids. White stays on var(--white); screen--preview-white-limited mutes it.
-@mixin _preview-stroke-vars {
-    @each $token, $hex in vars.$preview-color-palette {
-        @include _stroke-hex($token, $hex);
+// Limited palettes paint chromatic strokes with the panel accent their dither
+// art already uses, so a theme hue cannot leak color onto a panel that has no
+// such ink: violet-30 on a black/white/red/yellow rail is red-30. Preview mode
+// swaps in the accent's preview hex. Gray tokens keep the base rule's grays,
+// which is what the 1-bit rails do.
+@mixin _palette-stroke-vars($palette-id, $preview: false, $dark: false) {
+    $accents: map.get(vars.$palette-hue-accents, 'color-#{$palette-id}');
+
+    @each $hue in vars.$color-hues {
+        $hue-str: '' + $hue;
+        $accent: map.get($accents, $hue-str);
+        @include _palette-stroke-token($hue-str, $accent, $preview, $dark);
+
+        @each $step in vars.$color-shade-steps {
+            @include _palette-stroke-token('#{$hue-str}-#{$step}', '#{$accent}-#{$step}', $preview, $dark);
+        }
+    }
+}
+
+@mixin _palette-stroke-token($token, $accent-token, $preview, $dark) {
+    $target: if($dark, bg.dark-remap-token($accent-token), $accent-token);
+    $preview-hex: if($preview, map.get(vars.$preview-color-palette, $target), null);
+
+    @if $preview-hex {
+        @include _stroke-hex($token, $preview-hex);
+    } @else {
+        @include _stroke-color($token, $target);
     }
 }
 
@@ -959,6 +980,7 @@ $_limited-palette-paint-depth: 4;
         .screen.screen--dark-mode.screen--color-#{$palette-id}#{helpers.$theme-exempt} .inverse {
             @include _palette-bg-vars($palette-id);
             @include _palette-text-vars($palette-id);
+            @include _palette-stroke-vars($palette-id);
             @include _border-level-pattern-vars('borders--1bit');
             // Palette paint below replaces every chromatic token in this rule;
             // emit only the grayscale rail here to avoid 900 dead declarations.
@@ -973,7 +995,7 @@ $_limited-palette-paint-depth: 4;
         .screen--preview-colors .screen.screen--dark-mode.screen--color-#{$palette-id}#{helpers.$theme-exempt} .inverse {
             @include _palette-bg-vars($palette-id, $preview: true);
             @include _palette-text-vars($palette-id, $preview: true);
-            @include _preview-stroke-vars;
+            @include _palette-stroke-vars($palette-id, $preview: true);
             @include _border-level-pattern-vars('borders--1bit-preview');
             @include _border-token-pattern-vars('borders-token-preview', $chromatic: false);
             @include _border-token-palette-vars($palette-id, $preview: true);
@@ -1121,6 +1143,7 @@ $_limited-palette-paint-depth: 4;
             @include _palette-bg-vars($palette-id, $dark: true);
             @include _palette-text-vars($palette-id, $dark: true);
             @include _stroke-vars($dark: true);
+            @include _palette-stroke-vars($palette-id, $dark: true);
             @include _border-level-pattern-vars('borders--1bit', $dark: true);
             @include _border-token-pattern-vars('borders-token', $dark: true, $chromatic: false);
             @include _border-token-palette-vars($palette-id, $dark: true);
@@ -1132,7 +1155,7 @@ $_limited-palette-paint-depth: 4;
         .screen--preview-colors .screen.screen--color-#{$palette-id}#{helpers.$theme-exempt} .inverse {
             @include _palette-bg-vars($palette-id, $preview: true, $dark: true);
             @include _palette-text-vars($palette-id, $preview: true, $dark: true);
-            @include _preview-stroke-vars;
+            @include _palette-stroke-vars($palette-id, $preview: true, $dark: true);
             @include _border-level-pattern-vars('borders--1bit-preview', $dark: true);
             @include _border-token-pattern-vars('borders-token-preview', $dark: true, $chromatic: false);
             @include _border-token-palette-vars($palette-id, $preview: true, $dark: true);

--- a/app/assets/stylesheets/framework/config/_tokens_colors_generated.scss
+++ b/app/assets/stylesheets/framework/config/_tokens_colors_generated.scss
@@ -381,6 +381,69 @@ $preview-color-palette: (
   'blue-75': #E8EEF6
 );
 
+$palette-hue-accents: (
+  'color-3bwr': (
+    'red': 'red',
+    'orange': 'red',
+    'yellow': 'red',
+    'lime': 'red',
+    'green': 'red',
+    'cyan': 'red',
+    'blue': 'red',
+    'violet': 'red',
+    'purple': 'red',
+    'pink': 'red'
+  ),
+  'color-3bwy': (
+    'red': 'yellow',
+    'orange': 'yellow',
+    'yellow': 'yellow',
+    'lime': 'yellow',
+    'green': 'yellow',
+    'cyan': 'yellow',
+    'blue': 'yellow',
+    'violet': 'yellow',
+    'purple': 'yellow',
+    'pink': 'yellow'
+  ),
+  'color-4bwry': (
+    'red': 'red',
+    'orange': 'red',
+    'yellow': 'yellow',
+    'lime': 'yellow',
+    'green': 'yellow',
+    'cyan': 'yellow',
+    'blue': 'red',
+    'violet': 'red',
+    'purple': 'red',
+    'pink': 'red'
+  ),
+  'color-6a': (
+    'red': 'red',
+    'orange': 'red',
+    'yellow': 'yellow',
+    'lime': 'green',
+    'green': 'green',
+    'cyan': 'green',
+    'blue': 'blue',
+    'violet': 'blue',
+    'purple': 'blue',
+    'pink': 'red'
+  ),
+  'color-7a': (
+    'red': 'red',
+    'orange': 'orange',
+    'yellow': 'yellow',
+    'lime': 'green',
+    'green': 'green',
+    'cyan': 'green',
+    'blue': 'blue',
+    'violet': 'blue',
+    'purple': 'blue',
+    'pink': 'red'
+  )
+);
+
 $border-token-lines: (
   'black': ('solid', #000000),
   'gray-10': ('seq', #000000, #FFFFFF, 1),

--- a/lib/tasks/framework.rake
+++ b/lib/tasks/framework.rake
@@ -354,6 +354,20 @@ namespace :framework do
       ["'#{hue}': #{preview_hex.gsub('"', '')}"] + step_entries
     end
     preview_color_palette_scss = preview_palette_entries.join(",\n  ")
+
+    # Strokes are the only paint chain that has to be a single solid, so a limited
+    # palette resolves each hue to the framework hue nearest the panel accent its
+    # dither art already uses. Two-ink blends collapse to the primary accent.
+    base_hue_channels = manifest['color_hues'].index_with { |hue| hex_channels.call(manifest['color_palette'].fetch(hue)) }
+    nearest_base_hue = lambda do |hex|
+      accent = hex_channels.call(hex)
+      base_hue_channels.min_by { |_hue, channels| channels.zip(accent).sum { |channel, ink| (channel - ink)**2 } }.first
+    end
+    palette_hue_accents_scss = (manifest['hue_to_accents'] || {}).map do |palette_id, hue_accents|
+      body = hue_accents.map { |hue, accents| "'#{hue}': '#{nearest_base_hue.call(Array(accents).first)}'" }.join(",\n    ")
+      "'#{palette_id}': (\n    #{body}\n  )"
+    end.join(",\n  ")
+
     hues_scss = manifest['color_hues'].join(', ')
     steps_scss = manifest['color_shade_steps'].join(', ')
     color_fallback_content = manifest['color_to_gray_fallback'].map { |token, gray| "'#{token}': '#{gray}'" }.join(",\n  ")
@@ -383,6 +397,10 @@ namespace :framework do
 
       $preview-color-palette: (
         #{preview_color_palette_scss}
+      );
+
+      $palette-hue-accents: (
+        #{palette_hue_accents_scss}
       );
 
       $border-token-lines: (

--- a/spec/assets/stylesheets/framework_palette_stroke_substitution_spec.rb
+++ b/spec/assets/stylesheets/framework_palette_stroke_substitution_spec.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'open3'
+require 'tmpdir'
+
+# Limited-palette screens must resolve every chromatic stroke through the panel
+# accent their dither art already uses. Strokes are the solid-color chain behind
+# border lines, dividers, title-bar outlines and text-stroke--*, so a raw hue
+# here paints violet onto a panel whose inks are black, white, red and yellow.
+module PaletteStrokeSubstitution
+  # The palette rails, keyed by the first selector of each rule the mode-vars
+  # sheet emits for them.
+  RAILS = {
+    'light' => ->(id) { ".trmnl .screen.screen--color-#{id}," },
+    'preview' => ->(id) { ".trmnl .screen.screen--preview-colors.screen--color-#{id}," },
+    'dark' => ->(id) { ".trmnl .screen.screen--dark-mode.screen--color-#{id}:" },
+    'dark preview' => ->(id) { ".trmnl .screen.screen--dark-mode.screen--preview-colors.screen--color-#{id}:" }
+  }.freeze
+
+  DECLARATION = /--stroke-([a-z0-9-]+)-color:\s*([^;}]+)/
+
+  module_function
+
+  # The mode-vars sheet plus a dump of the two generated tables the substitution
+  # reads, so the spec checks the shipped accent data rather than a copy of it.
+  def css
+    @css ||= Dir.mktmpdir do |dir|
+      entry = File.join(dir, 'palette_strokes.scss')
+      output = File.join(dir, 'palette_strokes.css')
+      File.write(entry, <<~'SCSS')
+        @use 'framework/base/screen-mode-vars';
+        @use 'framework/config/tokens' as vars;
+
+        .probe-accents {
+            @each $palette-id, $accents in vars.$palette-hue-accents {
+                @each $hue, $accent in $accents {
+                    --#{$palette-id}-#{$hue}: #{$accent};
+                }
+            }
+        }
+
+        .probe-preview {
+            @each $token, $hex in vars.$preview-color-palette {
+                --#{$token}: #{$hex};
+            }
+        }
+      SCSS
+      _stdout, stderr, status = Open3.capture3(
+        'bundle', 'exec', 'sass', '--style=compressed', '--no-source-map',
+        "--load-path=#{Framework::Engine.root.join('app/assets/stylesheets')}",
+        entry, output
+      )
+      raise "sass failed: #{stderr}" unless status.success?
+
+      File.read(output)
+    end
+  end
+
+  # [selector, body] for every declaration block, at-rule wrappers unwrapped.
+  def blocks
+    @blocks ||= begin
+      found = []
+      selector_start = 0
+      index = 0
+      while (index = css.index(/[{}]/, index))
+        if css[index] == '}'
+          index += 1
+        else
+          selector = css[selector_start...index].strip
+          if selector.start_with?('@') && !selector.start_with?('@font-face', '@property')
+            index += 1
+          else
+            close = css.index('}', index)
+            found << [selector, css[(index + 1)...close]]
+            index = close + 1
+          end
+        end
+        selector_start = index
+      end
+      found
+    end
+  end
+
+  # A rule may restate a token, and the last declaration is the one that paints.
+  def strokes(needle)
+    match = blocks.find { |selector, _| selector.start_with?(needle) }
+    raise "no rule starting with #{needle}" if match.nil?
+
+    match.last.scan(DECLARATION).to_h { |token, value| [token, value.strip] }
+  end
+
+  def probe(selector)
+    blocks.find { |found, _| found == selector }.last.scan(/--([a-z0-9-]+):\s*([^;}]+)/)
+          .to_h { |name, value| [name, value.strip] }
+  end
+
+  def accent(palette_id, hue) = probe('.probe-accents').fetch("color-#{palette_id}-#{hue}")
+
+  def preview_hex(token) = probe('.probe-preview')[token]
+
+  # Custom properties merge across the equal-specificity `.screen` rules.
+  def base
+    @base ||= blocks.filter_map { |selector, body| body if selector == '.trmnl .screen' }
+                    .flat_map { |body| body.scan(DECLARATION) }
+                    .to_h { |token, value| [token, value.strip] }
+  end
+
+  def hues = @hues ||= Framework::ColorData.load.fetch('color_hues')
+
+  def steps = @steps ||= Framework::ColorData.load.fetch('color_shade_steps')
+
+  def palette_ids = @palette_ids ||= Framework::ColorData.load.fetch('color_palette_limited_ids')
+end
+
+RSpec.describe 'Framework limited palette stroke substitution' do
+  let(:probe) { PaletteStrokeSubstitution }
+
+  it 'binds chromatic strokes to their raw hue on the default screen rule' do
+    expect(probe.base.fetch('violet')).to eq('var(--violet)')
+  end
+
+  it 'paints violet through the red accent on the black/white/red/yellow rail' do
+    expect(probe.strokes('.trmnl .screen.screen--color-4bwry,').fetch('violet')).to eq('var(--red)')
+  end
+
+  it 'paints violet through the red accent preview hex on the preview rail' do
+    expect(probe.strokes('.trmnl .screen.screen--preview-colors.screen--color-4bwry,').fetch('violet'))
+      .to eq(probe.preview_hex('red'))
+  end
+
+  it 'mirrors the accent shade step on the dark rail' do
+    expect(probe.strokes('.trmnl .screen.screen--dark-mode.screen--color-4bwry:').fetch('violet-30'))
+      .to eq('var(--red-55)')
+  end
+
+  it 'leaves gray strokes to the default screen rule' do
+    expect(probe.strokes('.trmnl .screen.screen--color-4bwry,')).not_to include('gray-30')
+  end
+
+  PaletteStrokeSubstitution.palette_ids.each do |palette_id|
+    it "substitutes every chromatic stroke through the #{palette_id} accent table" do
+      light = probe.strokes(PaletteStrokeSubstitution::RAILS.fetch('light').call(palette_id))
+      preview = probe.strokes(PaletteStrokeSubstitution::RAILS.fetch('preview').call(palette_id))
+
+      leaks = probe.hues.flat_map do |hue|
+        accent = probe.accent(palette_id, hue)
+        ([nil] + probe.steps).filter_map do |step|
+          token = [hue, step].compact.join('-')
+          target = [accent, step].compact.join('-')
+          expected_preview = probe.preview_hex(target) || "var(--#{target})"
+          next if light[token] == "var(--#{target})" && preview[token] == expected_preview
+
+          "#{token}: #{light[token]} / #{preview[token]}"
+        end
+      end
+
+      expect(leaks).to be_empty,
+                       "#{palette_id} leaves #{leaks.length} chromatic strokes unsubstituted, " \
+                       "starting with #{leaks.first(3).join(', ')}"
+    end
+  end
+end


### PR DESCRIPTION
Strokes were the one paint chain on a limited-color palette that never went through the panel's accent table. `--stroke-<token>-color` fell through to the base `.screen` rule's raw hex, so a theme bound to violet painted a violet border line, divider or text outline on a black/white/red/yellow panel. The preview rails mapped strokes to the preview hex of the original hue, which leaked the same way.

Adds `_palette-stroke-vars`, which resolves every chromatic token through the accent its palette's dither art already uses and keeps the shade step, so violet-30 on 4bwry paints red-30 and violet paints red. Included on all four limited rails (plain, preview, dark, dark preview); it replaces `_preview-stroke-vars`. The accent table is generated from `framework_colors.yml` alongside the tile specs the bg and text mixins read.

A stroke has to be a single solid, so a two-ink blend collapses to its primary accent and an accent with no framework token of its own (7a's orange ink) resolves to the nearest base hue. Gray tokens are left to the base rule, which is what the 1-bit rails do.

The new spec compiles the mode vars and pins the substitution on every limited palette, plus the violet-on-4bwry repro. It fails 8 of 10 examples without the mixin.