### PR TITLE
Removed the second network trip that arming an adaptive icon cost

### DIFF
--- a/app/javascript/plugin-render/plugins.js
+++ b/app/javascript/plugin-render/plugins.js
@@ -3155,7 +3155,7 @@ function wrapAdaptiveForStroke(img) {
   } catch (_) { /* wrapping is decorative; the icon still renders unwrapped */ }
 }
 
-async function applyAdaptiveImages(root = document) {
+function applyAdaptiveImages(root = document) {
   const scope = root || document;
   // Only un-armed icons are processed and armed below; arming behavior is unchanged.
   const imgs = Array.from(scope.querySelectorAll('img.image--adaptive:not([data-adaptive])'));
@@ -3167,37 +3167,25 @@ async function applyAdaptiveImages(root = document) {
   let armed = 0;
   let skipped = 0;
 
-  const readAsDataURL = (blob) => new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => resolve(reader.result);
-    reader.onerror = () => reject(reader.error || new Error('read failed'));
-    reader.readAsDataURL(blob);
-  });
+  const arm = (img) => {
+    img.setAttribute('data-adaptive', 'true');
+    wrapAdaptiveForStroke(img);
+    armed += 1;
+  };
 
-  await Promise.all(imgs.map(async (img) => {
+  imgs.forEach((img) => {
     // Author-supplied mask source (manual form): trust it, just flip the gate.
-    if (img.style.getPropertyValue('--framework-icon-src').trim()) {
-      img.setAttribute('data-adaptive', 'true');
-      wrapAdaptiveForStroke(img);
-      armed += 1;
+    if (img.style.getPropertyValue('--framework-icon-src').trim()) return arm(img);
+
+    const src = img.currentSrc || img.src || '';
+    if (!src) {
+      skipped += 1;
       return;
     }
-    const src = img.currentSrc || img.src || '';
-    if (!src) return;
-    try {
-      const response = await fetch(src, { mode: 'cors', credentials: 'omit' });
-      if (!response.ok) throw new Error(`status ${response.status}`);
-      const dataUri = await readAsDataURL(await response.blob());
-      img.style.setProperty('--framework-icon-src', `url("${String(dataUri).replace(/"/g, '\\"')}")`);
-      img.setAttribute('data-adaptive', 'true');
-      wrapAdaptiveForStroke(img);
-      armed += 1;
-    } catch (_) {
-      // Icon is not readable (e.g. cross-origin host without CORS headers).
-      // Leave it as a plain image; recoloring is simply unavailable here.
-      skipped += 1;
-    }
-  }));
+    // A mask is not subject to CORS, so the icon's own url works even on another origin.
+    img.style.setProperty('--framework-icon-src', `url("${String(src).replace(/"/g, '\\"')}")`);
+    arm(img);
+  });
 
   // targets = total adaptive images present (already-armed + newly-armed candidates)
   // so the step reports consistently across re-terminalize passes. armed is the

--- a/test/runtime/terminalize/images.spec.js
+++ b/test/runtime/terminalize/images.spec.js
@@ -107,3 +107,79 @@ test('arms adaptive images and wraps a title-bar icon only once', async ({ page 
   expect(state.stats.every((stats) => stats.engineNames.includes('Adaptive images'))).toBe(true);
   expectNoUnexpectedErrors(browserSignals, state);
 });
+
+test.describe('arming an adaptive icon', () => {
+  const iconPath = '/__runtime-test__/icon.svg';
+  const otherOrigin = 'https://icons.example.test/icon.svg';
+
+  // Counts any read of the icon back over fetch(), which is how arming used to inline it.
+  const armIcon = async (page, src) => {
+    const browserSignals = await openRuntimePage(page);
+    await mountFixture(page, {
+      html: `<img id="icon" class="image--adaptive" src="${src}" alt="">`,
+    });
+    await page.evaluate((url) => {
+      window.__iconFetches = 0;
+      const realFetch = window.fetch;
+      window.fetch = function (...args) {
+        if (String(args[0]).includes(url)) window.__iconFetches += 1;
+        return realFetch.apply(this, args);
+      };
+    }, src);
+
+    await runTerminalize(page, 1);
+
+    const result = await page.evaluate(() => {
+      const icon = document.querySelector('#icon');
+      return {
+        armed: icon.dataset.adaptive,
+        source: icon.style.getPropertyValue('--framework-icon-src'),
+        iconFetches: window.__iconFetches,
+      };
+    });
+    return { browserSignals, result };
+  };
+
+  test.beforeEach(async ({ page }) => {
+    await page.route(`**${iconPath}`, (route) => route.fulfill({
+      body: '<svg xmlns="http://www.w3.org/2000/svg" width="4" height="4"><rect width="4" height="4"/></svg>',
+      contentType: 'image/svg+xml',
+    }));
+    await page.route(otherOrigin, (route) => route.fulfill({
+      body: '<svg xmlns="http://www.w3.org/2000/svg" width="4" height="4"><rect width="4" height="4"/></svg>',
+      contentType: 'image/svg+xml',
+    }));
+  });
+
+  test('masks it with the icon url', async ({ page }) => {
+    const { result } = await armIcon(page, iconPath);
+    // currentSrc resolves to an absolute url, so match the path rather than the whole value.
+    expect(result.source).toContain(iconPath);
+  });
+
+  test('does not copy the icon into the mask', async ({ page }) => {
+    const { result } = await armIcon(page, iconPath);
+    expect(result.source.startsWith('url("data:')).toBe(false);
+  });
+
+  test('does not read the icon back over the network', async ({ page }) => {
+    const { result } = await armIcon(page, iconPath);
+    expect(result.iconFetches).toBe(0);
+  });
+
+  test('arms an icon served from another origin', async ({ page }) => {
+    const { result } = await armIcon(page, otherOrigin);
+    expect(result.armed).toBe('true');
+  });
+
+  test('masks a cross-origin icon with its own url', async ({ page }) => {
+    const { result } = await armIcon(page, otherOrigin);
+    expect(result.source).toContain(otherOrigin);
+  });
+
+  test('reports no runtime errors while arming', async ({ page }) => {
+    const { browserSignals } = await armIcon(page, iconPath);
+    const state = await runtimeSignals(page);
+    expectNoUnexpectedErrors(browserSignals, state);
+  });
+});


### PR DESCRIPTION
An adaptive icon was armed by reading its own bytes back over fetch and inlining them as a data URI, because CSS cannot read an img's own src. The img tag had already loaded those bytes.

The mask now takes the icon's own url instead.

- on production renders the two fetches on a mashup cost 127ms to 416ms to retrieve 1.4KB to 5.9KB, and the base64 step that consumed them took about 1ms
- screenshotting four production mashups, swapping every armed icon to that url, and screenshotting again gives byte-identical PNGs
- across six production mashups the step goes from 37ms to 0ms at the median, every fetch disappears, and terminalize finishes 24ms sooner
- a mask is not subject to CORS, so icons on another origin arm now instead of falling back to a plain image
- removes the fetch, the FileReader helper and the async map

68 runtime tests pass. Six of them cover arming and four fail against the previous implementation.